### PR TITLE
Support for Minecraft 1.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-  runtimeOnly fg.deobf(group: 'ca.fireball1725.mods', name: 'DevWorld2-1.14.4', version: '1.0+')
+  runtimeOnly fg.deobf(group: 'ca.fireball1725.mods', name: 'DevWorld2-1.15.2', version: '1.0+')
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Minecraft Properties
-minecraft_version=1.14.4
-forge_version=28.1.40
+minecraft_version=1.15.2
+forge_version=31.0.0
 
 # MCP Mappings
 mcp_channel=snapshot
-mcp_version=20191009-1.14.3
+mcp_version=20200123-1.15.1
 
 # Project Properties
 project_name=DevWorld2

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[28,)"
+loaderVersion="[31,)"
 issueTrackerURL="https://github.com/FireBall1725/DevWorld2/issues"
 
 [[mods]]
@@ -13,13 +13,13 @@ description="DevWorld2 is a simple mod used to create a flat world with pre-defi
 [[dependencies.devworld2]]
   modId="forge"
   mandatory=true
-  versionRange="[28,)"
+  versionRange="[31,)"
   ordering="NONE"
   side="CLIENT"
 
 [[dependencies.devworld2]]
   modId="minecraft"
   mandatory=true
-  versionRange="[1.14.4]"
+  versionRange="[1.15.2]"
   ordering="NONE"
   side="CLIENT"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "devworld2 resources",
-        "pack_format": 4,
-        "_comment": "A pack_format of 4 requires json lang files. Note: we require v4 pack meta for all mods."
+        "pack_format": 5,
+        "_comment": "A pack_format of 5 requires json lang files and some texture changes from 1.15. Note: we require v5 pack meta for all mods."
     }
 }


### PR DESCRIPTION
This PR adds support for Minecraft 1.15.2

This is a simple build script and support file port as no source code changes were needed for this support.

Testing was still performed and all options such as creating world, loading, and deleting are working

<img width="966" alt="devworld-1 15 2" src="https://user-images.githubusercontent.com/1168966/73001186-0be0df80-3dd0-11ea-85ef-be74ef6f7f62.png">
